### PR TITLE
 Allow to use custom repos instead of the predefined ones

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,7 @@ class foreman (
   $authentication  = $foreman::params::authentication,
   $passenger       = $foreman::params::passenger,
   $ssl             = $foreman::params::ssl,
+  $custom_repo     = $foreman::params::custom_repo,
   $use_testing     = $foreman::params::use_testing,
   $railspath       = $foreman::params::railspath,
   $app_root        = $foreman::params::app_root,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,10 +1,12 @@
 class foreman::install {
-  class { '::foreman::install::repos': use_testing => $foreman::use_testing }
+  if ! $foreman::custom_repo {
+    class { '::foreman::install::repos': use_testing => $foreman::use_testing }
+  }
   case $::operatingsystem {
     Debian,Ubuntu:  {
       package {'foreman-sqlite3':
         ensure  => latest,
-        require => Class['foreman::install::repos'],
+        require => $foreman::custom_repo ? { true => [], default => Class['foreman::install::repos'] },
         notify  => [Class['foreman::service'],
                     Package['foreman']],
       }
@@ -14,7 +16,7 @@ class foreman::install {
 
   package {'foreman':
     ensure  => present,
-    require => Class['foreman::install::repos'],
+    require => $foreman::custom_repo ? { true => [], default => Class['foreman::install::repos'] },
     notify  => Class['foreman::service'],
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,6 +20,9 @@ class foreman::params {
   $ssl          = true
 
 # Advance configurations - no need to change anything here by default
+  # if set to true, no repo will be added by this module, letting you to
+  # set it to some custom location.
+  $custom_repo = false
   # allow usage of test / RC rpms as well
   $use_testing = true
   $railspath   = '/usr/share'


### PR DESCRIPTION
This lets modules that reuse this one to use their own repositories.

This pull request is based on changes in https://github.com/theforeman/puppet-foreman/pull/4. Although it doesn't depend on it directly, it was made on with the changes from there and therefore having the previous pull request merged first would be a good idea to avoid conflicts.
